### PR TITLE
Use Older Version of Apex

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,6 +36,7 @@ Install apex
 ```
 git clone https://github.com/NVIDIA/apex
 cd apex
+git checkout 22.04-dev
 pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 cd ..
 ```


### PR DESCRIPTION
The latest version of apex currently does not install, as mentioned here https://github.com/facebookresearch/ConvNeXt-V2/issues/52.

This issue with apex has also been reported here https://github.com/NVIDIA/apex/issues/1679

https://github.com/huggingface/transformers/pull/24351 suggests pinning apex to a specific commit, `cd apex && git checkout 82ee367f3da74b4cd62a1fb47aa9806f0f47b58b`, after which apex installs successfully.

However, that version of apex is incompatible with the version of torch used here, and I get this error https://github.com/NVIDIA/apex/issues/1532.

The previous link suggest using version `22.04-dev` (`cd apex && git checkout 22.04-dev`) of apex. With this, apex compiles successfully and `python ./main_finetune.py` also runs training using amp successfully.

If the authors can tell us the exact HEAD commit of apex version that they used, we can use that version instead!