### PR TITLE
Fix Minkowski GRN: Resolved normalization mismatch between dense and sparse

### DIFF
--- a/models/utils.py
+++ b/models/utils.py
@@ -31,7 +31,7 @@ class MinkowskiGRN(nn.Module):
         Nx_per_batch = Gx_per_batch / (Gx_per_batch.mean(dim=-1, keepdim=True) + 1e-6)
         out_feat = x.F + self.gamma * (x.F * Nx_per_batch[batch_index]) + self.beta
 
-        out = ME.SparseTensor(
+        out = SparseTensor(
             features=out_feat,
             coordinate_manager=x.coordinate_manager,
             coordinate_map_key=x.coordinate_map_key

--- a/test/Compared_GRN_Experiment.ipynb
+++ b/test/Compared_GRN_Experiment.ipynb
@@ -1,0 +1,481 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "import torch.optim as optim\n",
+    "import numpy as np\n",
+    "import random\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Standard GRN Experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([10, 6, 9, 512])\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2D Dense Tensor Sample\n",
+    "N,H,W,C=10,6,9,512\n",
+    "x=torch.rand(N,H,W,C)\n",
+    "print(x.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class GRN(nn.Module):\n",
+    "    \"\"\" GRN (Global Response Normalization) layer\n",
+    "    \"\"\"\n",
+    "    def __init__(self, dim):\n",
+    "        super().__init__()\n",
+    "        self.gamma = nn.Parameter(torch.zeros(1, 1, 1, dim))\n",
+    "        self.beta = nn.Parameter(torch.zeros(1, 1, 1, dim))\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        Gx = torch.norm(x, p=2, dim=(1,2), keepdim=True) # torch.Size([10, 1, 1, 512])\n",
+    "        Nx = Gx / (Gx.mean(dim=-1, keepdim=True) + 1e-6)\n",
+    "        return self.gamma * (x * Nx) + self.beta + x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([10, 1, 1, 512])\n",
+      "torch.Size([10, 1, 1, 1])\n",
+      "torch.Size([10, 1, 1, 512])\n",
+      "torch.Size([10, 6, 9, 512])\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1) Calculate Gx: the L2 norm of x across the height (dim=1) and width (dim=2) axes for each batch and channel.\n",
+    "# output => [batch_size, 1, 1, dim]\n",
+    "gx=torch.norm(x,p=2,dim=(1,2),keepdim=True)\n",
+    "print(gx.shape)\n",
+    "\n",
+    "# 2) Take the mean of Gx across the channel dimension (dim=-1)\n",
+    "# output => [batch_size, 1, 1, 1]\n",
+    "print(gx.mean(dim=-1,keepdim=True).shape)\n",
+    "\n",
+    "# 3) Compute Nx by dividing Gx by its mean across channels.\n",
+    "# output => [batch_size, 1, 1, dim]\n",
+    "nx=gx/(gx.mean(dim=-1,keepdim=True)+1e-6) \n",
+    "print(nx.shape) \n",
+    "\n",
+    "# 4) Apply the normalization to x using gamma and beta.\n",
+    "# output => [batch_size, H, W, C]\n",
+    "grn=GRN(C)\n",
+    "output=grn(x)\n",
+    "print(output.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Existing Sparse GRN Experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "coords shape = torch.Size([540, 3])\n",
+      "feats shape  = torch.Size([540, 512])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/k007ke/anaconda3/envs/Echo_CM/lib/python3.9/site-packages/MinkowskiEngine-0.5.4-py3.9-linux-x86_64.egg/MinkowskiEngine/__init__.py:36: UserWarning: The environment variable `OMP_NUM_THREADS` not set. MinkowskiEngine will automatically set `OMP_NUM_THREADS=16`. If you want to set `OMP_NUM_THREADS` manually, please export it on the command line before running a python script. e.g. `export OMP_NUM_THREADS=12; python your_program.py`. It is recommended to set it below 24.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "import MinkowskiEngine as ME\n",
+    "\n",
+    "#2D Sparse Tensor sample\n",
+    "\n",
+    "batch_size = 10\n",
+    "H = 6\n",
+    "W = 9\n",
+    "C = 512\n",
+    "\n",
+    "coords_list = []\n",
+    "feats_list = []\n",
+    "\n",
+    "# coord: (batch, h, w)\n",
+    "for b in range(batch_size):\n",
+    "    for x in range(H):\n",
+    "        for y in range(W):\n",
+    "            coords_list.append([b, x, y])\n",
+    "            feats_list.append(torch.randn(C))\n",
+    "\n",
+    "coords = torch.IntTensor(coords_list)  # (N, 3),  N = 10*6*9 = 540\n",
+    "feats = torch.stack(feats_list, dim=0) # (N, 512)\n",
+    "\n",
+    "sparse_tensor = ME.SparseTensor(\n",
+    "    features=feats,\n",
+    "    coordinates=coords\n",
+    ")\n",
+    "print(f\"coords shape = {sparse_tensor.C.shape}\")\n",
+    "print(f\"feats shape  = {sparse_tensor.F.shape}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class MinkowskiGRN(nn.Module):\n",
+    "    \"\"\" GRN layer for sparse tensors.\n",
+    "    \"\"\"\n",
+    "    def __init__(self, dim):\n",
+    "        super().__init__()\n",
+    "        self.gamma = nn.Parameter(torch.zeros(1, dim))\n",
+    "        self.beta = nn.Parameter(torch.zeros(1, dim))\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        cm = x.coordinate_manager\n",
+    "        in_key = x.coordinate_map_key\n",
+    "\n",
+    "        Gx = torch.norm(x.F, p=2, dim=0, keepdim=True)\n",
+    "        Nx = Gx / (Gx.mean(dim=-1, keepdim=True) + 1e-6)\n",
+    "        return ME.SparseTensor(\n",
+    "                self.gamma * (x.F * Nx) + self.beta + x.F,\n",
+    "                coordinate_map_key=in_key,\n",
+    "                coordinate_manager=cm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([540, 512])\n",
+      "torch.Size([1, 512])\n",
+      "torch.Size([1, 1])\n",
+      "torch.Size([1, 512])\n",
+      "torch.Size([540, 512])\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 0) sparse tensor.F is the feature matrix of shape [N, C]\n",
+    "# N is the number of valid points (not the batch size) so N = 10*6*9 = 540\n",
+    "x=sparse_tensor\n",
+    "print(x.F.shape)\n",
+    "\n",
+    "# 1) Calculate Gx: the L2 norm of x across the channel axis (dim=0)\n",
+    "# output => [1, C]\n",
+    "Gx = torch.norm(x.F, p=2, dim=0, keepdim=True)\n",
+    "print(Gx.shape)\n",
+    "\n",
+    "# 2) Take the mean of Gx across the last dimension (dim=-1)\n",
+    "# output => [1, 1]\n",
+    "print(Gx.mean(dim=-1, keepdim=True).shape)\n",
+    "\n",
+    "# 3) Compute Nx by dividing Gx by its mean across channels.\n",
+    "# output => [1, C]\n",
+    "Nx = Gx / (Gx.mean(dim=-1, keepdim=True) + 1e-6)\n",
+    "print(Nx.shape)\n",
+    "\n",
+    "# 4) Apply the normalization to x using gamma and beta.\n",
+    "# output => [N, C]\n",
+    "mgrn = MinkowskiGRN(C)\n",
+    "output = mgrn(x)\n",
+    "print(output.F.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Existing Minkowski GRN != Standard GRN"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dim=512\n",
+    "random_init=torch.rand(1,dim)\n",
+    "random_init_bias=torch.rand(1,dim)\n",
+    "stand_random_init=random_init.unsqueeze(1).unsqueeze(2)\n",
+    "stand_random_init_bias=random_init_bias.unsqueeze(1).unsqueeze(2)\n",
+    "\n",
+    "gamma = nn.Parameter(random_init)#(torch.zeros(1, dim))\n",
+    "beta = nn.Parameter(random_init_bias) #torch.zeros(1, dim))\n",
+    "stan_gamma = nn.Parameter(stand_random_init)\n",
+    "stan_beta = nn.Parameter(stand_random_init_bias)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# gamma, beta same value setting\n",
+    "class MinkowskiGRN(nn.Module):\n",
+    "    \"\"\" GRN layer for sparse tensors.\n",
+    "    \"\"\"\n",
+    "    def __init__(self, dim):\n",
+    "        super().__init__()\n",
+    "        self.gamma = gamma\n",
+    "        self.beta = beta\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        cm = x.coordinate_manager\n",
+    "        in_key = x.coordinate_map_key\n",
+    "\n",
+    "        Gx = torch.norm(x.F, p=2, dim=0, keepdim=True)\n",
+    "        Nx = Gx / (Gx.mean(dim=-1, keepdim=True) + 1e-6)\n",
+    "        return ME.SparseTensor(\n",
+    "                self.gamma * (x.F * Nx) + self.beta + x.F,\n",
+    "                coordinate_map_key=in_key,\n",
+    "                coordinate_manager=cm)\n",
+    "class GRN(nn.Module):\n",
+    "    \"\"\" GRN (Global Response Normalization) layer\n",
+    "    \"\"\"\n",
+    "    def __init__(self, dim):\n",
+    "        super().__init__()\n",
+    "        self.gamma = stan_gamma\n",
+    "        self.beta = stan_beta\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        Gx = torch.norm(x, p=2, dim=(1,2), keepdim=True) # torch.Size([10, 1, 1, 512])\n",
+    "        Nx = Gx / (Gx.mean(dim=-1, keepdim=True) + 1e-6)\n",
+    "        return self.gamma * (x * Nx) + self.beta + x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dense sample shape:  torch.Size([10, 6, 9, 512])\n",
+      "Sparse sample.F shape:  torch.Size([540, 512])\n",
+      "Dense GRN output shape:  torch.Size([10, 512, 6, 9])\n",
+      "Sparse GRN output shape:  torch.Size([10, 512, 6, 9])\n",
+      "result: \n",
+      "stand vs sparse : 0.011198032016820122\n"
+     ]
+    }
+   ],
+   "source": [
+    "from MinkowskiOps import (\n",
+    "    to_sparse,\n",
+    ")\n",
+    "N,H,W,C=10,6,9,512\n",
+    "sample=torch.rand(N, C, H, W).to(dtype=torch.float64)\n",
+    "\n",
+    "\n",
+    "Dense_Sample=sample.permute(0, 2, 3, 1)\n",
+    "print(\"Dense sample shape: \",Dense_Sample.shape)\n",
+    "Sparse_Sample=to_sparse(sample)\n",
+    "print(\"Sparse sample.F shape: \",Sparse_Sample.F.shape)\n",
+    "\n",
+    "standard_grn=GRN(512)\n",
+    "output_dense_=standard_grn(Dense_Sample)\n",
+    "output_dense=output_dense_.permute(0, 3, 1, 2)\n",
+    "print(\"Dense GRN output shape: \",output_dense.shape)\n",
+    "\n",
+    "sparse_grn=MinkowskiGRN(512)\n",
+    "output_sparse_=sparse_grn(Sparse_Sample)\n",
+    "output_sparse = output_sparse_.dense()[0]\n",
+    "print(\"Sparse GRN output shape: \",output_sparse.shape)\n",
+    "\n",
+    "print(\"result: \")\n",
+    "print(\"stand vs sparse :\", torch.abs(output_dense - output_sparse).mean().item())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Minkowski GRN update"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# class MinkowskiGRN_updated(nn.Module):\n",
+    "#     def __init__(self, dim):\n",
+    "#         super().__init__()\n",
+    "#         self.gamma = nn.Parameter(torch.zeros(1, dim))\n",
+    "#         self.beta = nn.Parameter(torch.zeros(1, dim))\n",
+    "\n",
+    "#     def forward(self, x):\n",
+    "#         batch_index = x.C[:, 0] \n",
+    "#         num_batches = batch_index.max().item() + 1\n",
+    "#         num_channels = x.F.shape[1]\n",
+    "\n",
+    "#         sum_of_squares = torch.zeros([num_batches, num_channels], device=x.F.device, dtype=x.F.dtype)\n",
+    "#         sum_of_squares.index_add_(dim=0, index=batch_index, source=x.F.square())\n",
+    "#         Gx_per_batch = sum_of_squares.sqrt()\n",
+    "\n",
+    "#         Nx_per_batch = Gx_per_batch / (Gx_per_batch.mean(dim=-1, keepdim=True) + 1e-6)\n",
+    "#         out_feat = x.F + self.gamma * (x.F * Nx_per_batch[batch_index]) + self.beta\n",
+    "\n",
+    "#         out = ME.SparseTensor(\n",
+    "#             features=out_feat,\n",
+    "#             coordinate_manager=x.coordinate_manager,\n",
+    "#             coordinate_map_key=x.coordinate_map_key\n",
+    "#         )\n",
+    "\n",
+    "#         return out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class MinkowskiGRN_updated(nn.Module):\n",
+    "    def __init__(self, dim):\n",
+    "        super().__init__()\n",
+    "        self.gamma = gamma\n",
+    "        self.beta = beta\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        batch_index = x.C[:, 0] \n",
+    "        num_batches = batch_index.max().item() + 1\n",
+    "        num_channels = x.F.shape[1]\n",
+    "\n",
+    "        sum_of_squares = torch.zeros([num_batches, num_channels], device=x.F.device, dtype=x.F.dtype)\n",
+    "        sum_of_squares.index_add_(dim=0, index=batch_index, source=x.F.square())\n",
+    "        Gx_per_batch = sum_of_squares.sqrt()\n",
+    "\n",
+    "        Nx_per_batch = Gx_per_batch / (Gx_per_batch.mean(dim=-1, keepdim=True) + 1e-6)\n",
+    "        out_feat = x.F + self.gamma * (x.F * Nx_per_batch[batch_index,:]) + self.beta\n",
+    "\n",
+    "        out = ME.SparseTensor(\n",
+    "            features=out_feat,\n",
+    "            coordinate_manager=x.coordinate_manager,\n",
+    "            coordinate_map_key=x.coordinate_map_key\n",
+    "        )\n",
+    "\n",
+    "        return out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dense sample shape:  torch.Size([10, 6, 9, 512])\n",
+      "Sparse sample.F shape:  torch.Size([540, 512])\n",
+      "Dense GRN output shape:  torch.Size([10, 512, 6, 9])\n",
+      "Sparse GRN output shape:  torch.Size([10, 512, 6, 9])\n",
+      "result: \n",
+      "stand vs sparse 5.8333715984234266e-18\n"
+     ]
+    }
+   ],
+   "source": [
+    "from MinkowskiOps import (\n",
+    "    to_sparse,\n",
+    ")\n",
+    "N,H,W,C=10,6,9,512\n",
+    "sample=torch.rand(N, C, H, W).to(dtype=torch.float64)\n",
+    "\n",
+    "Dense_Sample=sample.permute(0, 2, 3, 1)\n",
+    "print(\"Dense sample shape: \",Dense_Sample.shape)\n",
+    "Sparse_Sample=to_sparse(sample)\n",
+    "print(\"Sparse sample.F shape: \",Sparse_Sample.F.shape)\n",
+    "\n",
+    "standard_grn=GRN(512)\n",
+    "output_dense_=standard_grn(Dense_Sample)\n",
+    "output_dense=output_dense_.permute(0, 3, 1, 2)\n",
+    "print(\"Dense GRN output shape: \",output_dense.shape)\n",
+    "\n",
+    "sparse_grn_update=MinkowskiGRN_updated(512)\n",
+    "output_sparse_update=sparse_grn_update(Sparse_Sample)\n",
+    "output_sparse_update = output_sparse_update.dense()[0]\n",
+    "print(\"Sparse GRN output shape: \",output_sparse_update.shape)\n",
+    "\n",
+    "print(\"result: \")\n",
+    "print(\"stand vs sparse\", torch.abs(output_dense - output_sparse_update).mean().item())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Echo_CM",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
 Standard GRN normalizes across the batch and channel dimensions in a dense tensor, whereas Minkowski GRN normalizes over the valid points and channel dimensions in a sparse tensor.

## Standard GRN:

- Normalization Basis: Per batch and channel.
-  sample : (batch_size = 10, H = 6, W = 9, C = 512)
- Process:
```ruby
# 1) Calculate Gx: the L2 norm of x across the height (dim=1) and width (dim=2) axes for each batch and channel.
# output => [batch_size, 1, 1, dim]

gx=torch.norm(x,p=2,dim=(1,2),keepdim=True)
print(gx.shape)

# 2) Take the mean of Gx across the channel dimension (dim=-1)
# output => [batch_size, 1, 1, 1]
print(gx.mean(dim=-1,keepdim=True).shape)

# 3) Compute Nx by dividing Gx by its mean across channels.
# output => [batch_size, 1, 1, dim]

nx=gx/(gx.mean(dim=-1,keepdim=True)+1e-6) 
print(nx.shape) 

# 4) Apply the normalization to x using gamma and beta.
# output => [batch_size, H, W, C]

grn=GRN(C)
output=grn(x)
print(output.shape)
```

## Minkowski GRN:

- Normalization Basis: Over valid points and channels.
- Process
```ruby
# 0) sparse tensor.F is the feature matrix of shape [N, C]
# N is the number of valid points (not the batch size) so N = 10*6*9 = 540
x=sparse_tensor
print(x.F.shape)

# 1) Calculate Gx: the L2 norm of x across the channel axis (dim=0)
# output => [1, C]
Gx = torch.norm(x.F, p=2, dim=0, keepdim=True)
print(Gx.shape)

# 2) Take the mean of Gx across the last dimension (dim=-1)
# output => [1, 1]
print(Gx.mean(dim=-1, keepdim=True).shape)

# 3) Compute Nx by dividing Gx by its mean across channels.
# output => [1, C]
Nx = Gx / (Gx.mean(dim=-1, keepdim=True) + 1e-6)
print(Nx.shape)

# 4) Apply the normalization to x using gamma and beta.
# output => [N, C]
mgrn = MinkowskiGRN(C)
output = mgrn(x)
print(output.F.shape)
```
## Minkowski GRN vs Standard GRN Result
![grn_output_compare](https://github.com/user-attachments/assets/7c7cf2fb-8768-476b-b115-1b717d584b48)
